### PR TITLE
Poll every 100 milliseconds for file readiness

### DIFF
--- a/convert.js
+++ b/convert.js
@@ -142,7 +142,7 @@ ConversionService.prototype.checkConversionState = function(conversionState, wor
             checkStatus(response);
           }
         })
-      }, 30000);
+      }, 100);
     }
     else if(info.state === 'complete') {
       callback(undefined, info);


### PR DESCRIPTION
30 seconds is overkill, confusing users (it leads to think that the conversion itself took more than 30 seconds).